### PR TITLE
Fix broken dependency with pillow 11.2.0

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 aiohttp==3.11.15
 cattrs==24.1.3
 fonttools[ufo,unicode]==4.56.0
-pillow==11.2.0
+pillow==11.2.1
 pyyaml==6.0.2
 ufomerge==1.8.2
 watchfiles==1.0.4


### PR DESCRIPTION
As per https://pillow.readthedocs.io/en/stable/releasenotes/11.2.1.html version 11.20.0 is cancelled and removed from pypi.

Fix the broken dependency by bumping to 11.2.1 as recommended by upstream